### PR TITLE
Add configurable frontend base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # hawar-comp
+
+## Configuration
+
+The React frontend reads its API endpoint from `frontend/src/config.js`. The file exports an object with a `baseURL` property pointing to the backend server:
+
+```javascript
+const API_CONFIG = {
+  baseURL: 'http://localhost:8000',
+};
+
+export default API_CONFIG;
+```
+
+Modify `baseURL` to match the host and port of your API. For example, when running in production you might set it to `https://api.example.com`. You can create different copies of this file for development, staging, and production environments as needed.
+

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -5,7 +5,7 @@
 /.pnp
 .pnp.js
 
-/src/config.js
+!/src/config.js
 # testing
 /coverage
 

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,0 +1,5 @@
+const API_CONFIG = {
+  baseURL: 'http://localhost:8000',
+};
+
+export default API_CONFIG;


### PR DESCRIPTION
## Summary
- export `API_CONFIG` from `frontend/src/config.js`
- track config.js in git
- document how to change the `baseURL`

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686377a062108330a2278f23f27c4f1d