### PR TITLE
Add sample seeders and transformation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,15 @@ export default API_CONFIG;
 ```
 
 Modify `baseURL` to match the host and port of your API. For example, when running in production you might set it to `https://api.example.com`. You can create different copies of this file for development, staging, and production environments as needed.
+
+## Seeding Example Data
+
+Run the Laravel seeders after configuring your `.env` connection:
+
+```bash
+php artisan migrate
+php artisan db:seed
+```
+
+This populates the lookup tables (`member_category`, `member_relation`, `member_status`, `membership_renew_settings`) and a few sample records in `member_details`.
+

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -2,8 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -13,11 +11,17 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        // Lookup tables first
+        $this->call([
+            MemberCategorySeeder::class,
+            MemberRelationSeeder::class,
+            MemberStatusSeeder::class,
+            MembershipRenewSettingsSeeder::class,
+        ]);
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        // Core member data
+        $this->call([
+            MemberDetailsSeeder::class,
         ]);
     }
 }

--- a/backend/database/seeders/MemberCategorySeeder.php
+++ b/backend/database/seeders/MemberCategorySeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Seed the member_category lookup table.
+ */
+class MemberCategorySeeder extends Seeder
+{
+    public function run(): void
+    {
+        DB::table('member_category')->insert([
+            ['id' => 1, 'name' => 'Primary'],
+            ['id' => 2, 'name' => 'Family'],
+            ['id' => 3, 'name' => 'Honorary'],
+        ]);
+    }
+}

--- a/backend/database/seeders/MemberDetailsSeeder.php
+++ b/backend/database/seeders/MemberDetailsSeeder.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
+
+/**
+ * Seed core member details using normalized sample records.
+ */
+class MemberDetailsSeeder extends Seeder
+{
+    public function run(): void
+    {
+        DB::table('member_details')->insert([
+            [
+                'id' => 1,
+                'member_code' => '1938',
+                'name' => 'إيمان عبد العليم محمد إسماعيل',
+                'national_id' => '1200121',
+                'birth_date' => '1974-08-21',
+                'join_date' => '2006-08-14',
+                'gender' => 'F',
+                'category_id' => 1,
+                'relation_id' => 1,
+                'status_id' => 1,
+                'address' => '10مساكن المينا ع 10 شقه8',
+                'phone' => '0163448944',
+                'notes' => 'رقم الزوج1937',
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+            [
+                'id' => 2,
+                'member_code' => '1968',
+                'name' => 'أمجد أحمد إبراهيم إبراهيم النجار',
+                'national_id' => '1201938',
+                'birth_date' => '1975-03-20',
+                'join_date' => '2006-08-14',
+                'gender' => 'M',
+                'category_id' => 1,
+                'relation_id' => 1,
+                'status_id' => 1,
+                'address' => '5ش أبو هريرة تقسيم سامية الجمل',
+                'phone' => '01221088209',
+                'notes' => 'رقم الزوجة 1969',
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+            [
+                'id' => 3,
+                'member_code' => '9093',
+                'name' => 'ولاء صبري محمود سالم صيام',
+                'national_id' => '28109120103706',
+                'birth_date' => '1981-09-12',
+                'join_date' => '2022-07-13',
+                'gender' => 'F',
+                'category_id' => 1,
+                'relation_id' => 1,
+                'status_id' => 1,
+                'address' => '11 ش الترعه بجوار مخازن ربيع للسيراميك',
+                'phone' => '01222216237',
+                'notes' => null,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+        ]);
+    }
+}

--- a/backend/database/seeders/MemberRelationSeeder.php
+++ b/backend/database/seeders/MemberRelationSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Seed the member_relation lookup table.
+ */
+class MemberRelationSeeder extends Seeder
+{
+    public function run(): void
+    {
+        DB::table('member_relation')->insert([
+            ['id' => 1, 'name' => 'Self'],
+            ['id' => 2, 'name' => 'Spouse'],
+            ['id' => 3, 'name' => 'Child'],
+            ['id' => 4, 'name' => 'Parent'],
+        ]);
+    }
+}

--- a/backend/database/seeders/MemberStatusSeeder.php
+++ b/backend/database/seeders/MemberStatusSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Seed the member_status lookup table.
+ */
+class MemberStatusSeeder extends Seeder
+{
+    public function run(): void
+    {
+        DB::table('member_status')->insert([
+            ['id' => 1, 'name' => 'Active'],
+            ['id' => 2, 'name' => 'Suspended'],
+            ['id' => 3, 'name' => 'Expired'],
+        ]);
+    }
+}

--- a/backend/database/seeders/MembershipRenewSettingsSeeder.php
+++ b/backend/database/seeders/MembershipRenewSettingsSeeder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
+
+/**
+ * Seed membership renewal fees and settings.
+ */
+class MembershipRenewSettingsSeeder extends Seeder
+{
+    public function run(): void
+    {
+        DB::table('membership_renew_settings')->insert([
+            [
+                'id' => 1,
+                'category_id' => 1,
+                'year' => 2024,
+                'fee_amount' => 75.00,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+            [
+                'id' => 2,
+                'category_id' => 2,
+                'year' => 2024,
+                'fee_amount' => 25.00,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+        ]);
+    }
+}

--- a/backend/scripts/transform_members.py
+++ b/backend/scripts/transform_members.py
@@ -1,0 +1,65 @@
+import csv
+from datetime import datetime
+from pathlib import Path
+
+# Mapping dictionaries for cleaning legacy data
+GENDER_MAP = {
+    'ذكر': 'M',
+    'أنثى': 'F',
+}
+
+STATUS_MAP = {
+    'مفعل': 'Active',
+    'موقوف': 'Suspended',
+    'ملغي': 'Expired',
+}
+
+RELATION_MAP = {
+    'زوج': 'Spouse',
+    'زوجة': 'Spouse',
+    'ابن': 'Child',
+    'إبن': 'Child',
+    'ابنة': 'Child',
+    'إبنة': 'Child',
+    'والد': 'Parent',
+    'والدة': 'Parent',
+}
+
+def parse_date(value: str):
+    """Return date in YYYY-MM-DD or None."""
+    value = value.strip()
+    for fmt in ('%d-%m-%Y', '%Y-%m-%d'):  # legacy files use both styles
+        try:
+            return datetime.strptime(value, fmt).strftime('%Y-%m-%d')
+        except ValueError:
+            continue
+    return None
+
+
+def clean_row(row: dict) -> dict:
+    """Clean and normalize a raw CSV row from legacy members."""
+    return {
+        'name': row.get('Mem_Name'),
+        'member_code': row.get('Mem_Code'),
+        'national_id': row.get('Mem_NID') or None,
+        'birth_date': parse_date(row.get('Mem_BOD', '')),
+        'join_date': parse_date(row.get('Mem_JoinDate', '')),
+        'gender': GENDER_MAP.get(row.get('Mem_Sex', '').strip()),
+        'status': STATUS_MAP.get(row.get('Mem_Status', '').strip()),
+        'relation': RELATION_MAP.get(row.get('Mem_Relation', '').strip()),
+        'address': row.get('Mem_Address'),
+        'mobile': row.get('Mem_Mobile'),
+    }
+
+
+def transform(csv_path: Path):
+    with csv_path.open(newline='', encoding='utf-8') as fh:
+        reader = csv.DictReader(fh)
+        cleaned = [clean_row(r) for r in reader]
+    return cleaned
+
+if __name__ == '__main__':
+    import json, sys
+    path = Path(sys.argv[1])
+    records = transform(path)
+    json.dump(records, sys.stdout, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## Summary
- add seeder classes for member lookup tables and member details
- include a Python helper script for transforming legacy member data
- wire new seeders in `DatabaseSeeder`
- document how to run seeders

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863bc16dae88330808204fbf1e797b0