### PR TITLE
Add legacy import command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,7 @@ php artisan db:seed
 
 This populates the lookup tables (`member_category`, `member_relation`, `member_status`, `membership_renew_settings`) and a few sample records in `member_details`.
 
+
+## Data Migration
+
+For instructions on migrating legacy membership records into the Laravel schema see [docs/migration.md](docs/migration.md).

--- a/backend/app/Console/Commands/ImportLegacyMembers.php
+++ b/backend/app/Console/Commands/ImportLegacyMembers.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use App\Models\Member;
+use App\Models\MemberCategory;
+use App\Models\MemberRelation;
+use App\Models\MemberStatus;
+use App\Models\Fee;
+
+class ImportLegacyMembers extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'import:legacy-members {file}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Import cleaned legacy member CSV into normalized tables';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $path = $this->argument('file');
+        if (!file_exists($path)) {
+            $this->error("File not found: $path");
+            return 1;
+        }
+
+        DB::beginTransaction();
+        try {
+            $rows = array_map('str_getcsv', file($path));
+            $header = array_map('trim', array_shift($rows));
+            foreach ($rows as $row) {
+                $data = array_combine($header, $row);
+                $member = Member::create([
+                    'Mem_Name'   => $data['name'] ?? null,
+                    'Mem_Code'   => $data['member_code'] ?? null,
+                    'Mem_BOD'    => $data['birth_date'] ?? null,
+                    'Mem_NID'    => $data['national_id'] ?? null,
+                    'Mem_JoinDate' => $data['join_date'] ?? null,
+                    'Mem_Sex'    => $data['gender'] ?? null,
+                    'category_id' => MemberCategory::where('name', $data['category'])->value('id'),
+                    'relation_id' => MemberRelation::where('name', $data['relation'])->value('id'),
+                    'status_id'   => MemberStatus::where('name', $data['status'])->value('id'),
+                ]);
+
+                if (!empty($data['fee_amount'])) {
+                    Fee::create([
+                        'member_id' => $member->id,
+                        'fiscal_year' => $data['fee_year'] ?? null,
+                        'amount' => $data['fee_amount'],
+                    ]);
+                }
+            }
+            DB::commit();
+            Log::info('Legacy import finished successfully');
+            $this->info('Import completed');
+            return 0;
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            Log::error('Legacy import failed: '.$e->getMessage());
+            $this->error($e->getMessage());
+            return 1;
+        }
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+
+class Kernel extends ConsoleKernel
+{
+    /**
+     * Register the commands for the application.
+     */
+    protected function commands(): void
+    {
+        $this->load(__DIR__.'/Commands');
+
+        require base_path('routes/console.php');
+    }
+
+    /**
+     * Define the application's command schedule.
+     */
+    protected function schedule(Schedule $schedule): void
+    {
+        // $schedule->command('inspire')->hourly();
+    }
+}

--- a/backend/scripts/transform_members.py
+++ b/backend/scripts/transform_members.py
@@ -60,6 +60,19 @@ def transform(csv_path: Path):
 
 if __name__ == '__main__':
     import json, sys
-    path = Path(sys.argv[1])
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Clean legacy member CSV data")
+    parser.add_argument("file", help="Path to legacy CSV")
+    parser.add_argument("--csv", action="store_true", help="Output CSV instead of JSON")
+    args = parser.parse_args()
+
+    path = Path(args.file)
     records = transform(path)
-    json.dump(records, sys.stdout, ensure_ascii=False, indent=2)
+
+    if args.csv:
+        writer = csv.DictWriter(sys.stdout, fieldnames=records[0].keys())
+        writer.writeheader()
+        writer.writerows(records)
+    else:
+        json.dump(records, sys.stdout, ensure_ascii=False, indent=2)

--- a/backend/tests/Feature/ImportLegacyMembersTest.php
+++ b/backend/tests/Feature/ImportLegacyMembersTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\MemberCategory;
+use App\Models\MemberRelation;
+use App\Models\MemberStatus;
+
+class ImportLegacyMembersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_import_command_inserts_member(): void
+    {
+        MemberCategory::create(['id' => 1, 'name' => 'Primary']);
+        MemberRelation::create(['id' => 1, 'name' => 'Self']);
+        MemberStatus::create(['id' => 1, 'name' => 'Active']);
+
+        $csv = tempnam(sys_get_temp_dir(), 'legacy');
+        file_put_contents($csv, "name,member_code,birth_date,join_date,gender,status,relation\n".
+            "اختبار,100,1970-01-01,2024-01-01,M,Active,Self\n");
+
+        $this->artisan('import:legacy-members '.$csv)
+            ->assertExitCode(0);
+
+        $this->assertDatabaseHas('members', [
+            'Mem_Name' => 'اختبار',
+            'Mem_Code' => '100',
+        ]);
+    }
+}

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,56 @@
+# خطة ترحيل البيانات
+
+توضح هذه الوثيقة خطوات ترحيل بيانات الأعضاء والاشتراكات من الملفات القديمة إلى قاعدة البيانات الجديدة داخل تطبيق Laravel.
+
+## 1. تجهيز الجداول
+
+```bash
+php artisan migrate
+php artisan db:seed
+```
+
+يتم إنشاء الجداول الجديدة مع تعبئة جداول القوائم (`member_categories` وغيرها).
+
+## 2. تنظيف البيانات القديمة
+
+استخدم السكربت Python الموجود في `backend/scripts/transform_members.py` لتحويل ملف SQL أو CSV القديم إلى ملف CSV نظيف:
+
+```bash
+python backend/scripts/transform_members.py path/to/legacy.csv > clean.csv
+```
+
+يجب أن يحتوي الملف الناتج على الحقول:
+`name,member_code,national_id,birth_date,join_date,gender,status,relation,fee_year,fee_amount`.
+
+## 3. استيراد البيانات
+
+بعد الحصول على الملف النظيف يتم تشغيل الأمر الآتي:
+
+```bash
+php artisan import:legacy-members clean.csv
+```
+
+يقوم الأمر بإضافة الأعضاء والرسوم في جداول النظام الجديدة ضمن معاملة واحدة، وتتم كتابة سجل بالنتيجة في `storage/logs/laravel.log`.
+
+## 4. الجدولة التلقائية
+
+يمكن إضافة جدولة في `app/Console/Kernel.php` لتشغيل الأمر دوريًا:
+
+```php
+protected function schedule(Schedule $schedule): void
+{
+    $schedule->command('import:legacy-members clean.csv')->daily();
+}
+```
+
+## 5. التحقق بعد الترحيل
+
+- تنفيذ اختبارات PHPUnit:
+
+```bash
+phpunit
+```
+
+- مراجعة عدد السجلات في جدول `members` ومطابقتها مع الملف النظيف.
+- التأكد من عدم وجود سجلات رسوم في جدول `fees` بدون عضو مرتبط.
+


### PR DESCRIPTION
## Summary
- add console kernel and ImportLegacyMembers command
- expand transform_members.py with CLI options
- document full import process in docs/migration.md
- link documentation in README
- add feature test for import command

## Testing
- `./vendor/bin/phpunit --testdox` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6863d5c392708330b86d887957e02913