### PR TITLE
Add helper script for MySQL transfer

### DIFF
--- a/legacy_db_transformer/.env.example
+++ b/legacy_db_transformer/.env.example
@@ -1,9 +1,10 @@
 # Directory containing legacy SQL dump files
-INPUT_DIR=./legacy_dumps
+INPUT_DIR=./sqls
 
 # Directory to place cleaned SQL files
 OUTPUT_DIR=./clean_dumps
 
 # Database connection string (optional)
-# Example: sqlite:///staging.db
+# Example using MySQL:
+# mysql+pymysql://askar:Askar@1984@127.0.0.1:3306/askar?charset=utf8mb4
 DB_CONN_STRING=

--- a/legacy_db_transformer/README.md
+++ b/legacy_db_transformer/README.md
@@ -33,3 +33,16 @@ The script reads all `*.sql` files from `INPUT_DIR`, fixes the relationships, an
 * **Output**: Cleaned `INSERT` files in the output directory or data inserted into a staging database.
 
 Progress and errors are logged to stdout using Python's `logging` module.
+
+### Example MySQL Transfer
+
+For a quick start with MySQL you can use the helper script `transfer_sqls.py`.
+It reads all `.sql` files from the `sqls` folder and loads them into the
+database specified by the connection string:
+
+```bash
+python transfer_sqls.py \
+  --db mysql+pymysql://askar:Askar@1984@127.0.0.1:3306/askar
+```
+
+Make sure `pymysql` is installed by installing `requirements.txt` first.

--- a/legacy_db_transformer/requirements.txt
+++ b/legacy_db_transformer/requirements.txt
@@ -2,3 +2,4 @@ sqlparse
 pandas
 SQLAlchemy
 python-dotenv
+pymysql

--- a/legacy_db_transformer/transfer_sqls.py
+++ b/legacy_db_transformer/transfer_sqls.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""Utility to load legacy SQL files into a MySQL database."""
+import argparse
+import logging
+from pathlib import Path
+from sqlalchemy import create_engine
+
+from transform_legacy_db import process_file
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+
+def run(db_conn: str, input_dir: Path) -> None:
+    """Process all `.sql` files from *input_dir* and load them using *db_conn*."""
+    engine = create_engine(db_conn)
+    for sql_file in input_dir.glob("*.sql"):
+        try:
+            process_file(sql_file, engine)
+        except Exception as exc:
+            logging.exception("Failed to process %s: %s", sql_file, exc)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Load legacy SQL files into MySQL")
+    parser.add_argument(
+        "--db",
+        default="mysql+pymysql://askar:Askar@1984@127.0.0.1:3306/askar",
+        help="SQLAlchemy connection string",
+    )
+    parser.add_argument(
+        "--dir",
+        default="sqls",
+        help="Directory containing legacy SQL files",
+    )
+    args = parser.parse_args()
+    run(args.db, Path(args.dir))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add example environment values for the DB transformer
- document MySQL helper usage in the README
- include `pymysql` in requirements
- provide `transfer_sqls.py` script for loading SQL dumps

## Testing
- `python -m py_compile legacy_db_transformer/transfer_sqls.py`
- `python -m py_compile legacy_db_transformer/transform_legacy_db.py`
- `python -m pip install -q -r legacy_db_transformer/requirements.txt` *(fails: Could not connect to pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_6863ee5a3dc08330975b3dadc18844c0