### PR TITLE
Improve legacy member transformer

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -13,10 +13,10 @@ php artisan db:seed
 
 ## 2. تنظيف البيانات القديمة
 
-استخدم السكربت Python الموجود في `backend/scripts/transform_members.py` لتحويل ملف SQL أو CSV القديم إلى ملف CSV نظيف:
+استخدم السكربت Python الموجود في `backend/scripts/transform_members.py` لتحويل ملف SQL أو CSV القديم إلى ملف CSV نظيف مع إزالة التكرارات:
 
 ```bash
-python backend/scripts/transform_members.py path/to/legacy.csv > clean.csv
+python backend/scripts/transform_members.py path/to/legacy.sql --csv > clean.csv
 ```
 
 يجب أن يحتوي الملف الناتج على الحقول:


### PR DESCRIPTION
## Summary
- extend legacy transformation mapping with membership categories
- support SQL dumps and deduplicate legacy rows
- document new transformation usage

## Testing
- `python3 -m py_compile backend/scripts/transform_members.py`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68642f07b5b48330bf7c115f1cefe143